### PR TITLE
Set code with examples for the new KubeOne Remote

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,39 @@
+// Copyright 2020 The KubeOne-Remote Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package config provides the configuration for the work of
+// KubeOne Remote. It also provides the functionality to read the
+// configuration from an io.Reader.
+package config
+
+import (
+	"io"
+)
+
+// Flag is the combination of a flag name and an optional value.
+type Flag struct {
+	Name  string
+	Value *string
+}
+
+// Config contains all needed parameters.
+type Config struct {
+	Flags []Flag
+}
+
+// Read retrieves data from an io.Reader and unmarshals it into the
+// Config structure.
+func Read(in io.Reader) (Config, error) {
+	return Config{}, nil
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,7 +29,8 @@ type Flag struct {
 
 // Config contains all needed parameters.
 type Config struct {
-	Flags []Flag
+	Command string
+	Flags   []Flag
 }
 
 // Read retrieves data from an io.Reader and unmarshals it into the

--- a/pkg/local/execute.go
+++ b/pkg/local/execute.go
@@ -1,0 +1,33 @@
+// Copyright 2020 The KubeOne-Remote Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package local
+
+import (
+	"golang.org/x/crypto/ssh"
+
+	"github.com/kubermatic-labs/kubeone-remote/pkg/config"
+)
+
+// PrepareSSHCommand creates the command to be run on the controller
+// node based on the config.
+func PrepareSSHCommand(cfg config.Config) string {
+	return ""
+}
+
+// PrepareSSHSession establishes the SSH session to run the command.
+// It has to be closed by the caller.
+func PrepareSSHSession(cfg config.Config) (*ssh.Session, error) {
+	return &ssh.Session{}, nil
+}

--- a/pkg/local/local.go
+++ b/pkg/local/local.go
@@ -1,0 +1,56 @@
+// Copyright 2020 The KubeOne-Remote Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package local provides the functions needed for the setup of
+// KubeOne-Remote from the local node on the remote controller
+// node. In the second step it executes the command remotely via
+// SSH.
+package local
+
+import (
+	"fmt"
+
+	"github.com/kubermatic-labs/kubeone-remote/pkg/config"
+)
+
+// Setup manages all needed steps on remote side to make KubeOne-Remote
+// working there.
+func Setup() (config.Config, error) {
+	// TODO
+	// - Parse flags
+	// - Check command
+	// - Read config
+	// - Exec pre-run tasks
+	// - Copy KubeOne Remote
+	return config.Config{}, nil
+}
+
+// Execute performes the remote kubeone-remote command with all needed
+// environment variables and parameters in a tmux via SSH.
+func Execute(cfg config.Config) error {
+	cmd := PrepareSSHCommand(cfg)
+
+	session, err := PrepareSSHSession(cfg)
+	if err != nil {
+		return fmt.Errorf("establishing SSH session failed: %v", err)
+	}
+	defer session.Close()
+
+	err = session.Run(cmd)
+	if err != nil {
+		return fmt.Errorf("running SSH command failed: %v", err)
+	}
+
+	return nil
+}

--- a/pkg/local/setup.go
+++ b/pkg/local/setup.go
@@ -1,0 +1,35 @@
+// Copyright 2020 The KubeOne-Remote Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package local
+
+import (
+	"github.com/kubermatic-labs/kubeone-remote/pkg/config"
+)
+
+// IsValidCommand checks if the given command is a valid one.
+func IsValidCommand(cmd string) bool {
+	return false
+}
+
+// PreRunLocalTasks performs initial configured tasks.
+func PreRunLocalTasks(cfg config.Config) error {
+	return nil
+}
+
+// CopyKubeOneRemote installs a KubeOne Remote copy on the controller
+// node for remote execution.
+func CopyKubeOneRemote(cfg config.Config) error {
+	return nil
+}

--- a/pkg/remote/execute/execute.go
+++ b/pkg/remote/execute/execute.go
@@ -1,0 +1,37 @@
+// Copyright 2020 The KubeOne-Remote Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package execute provides the functions to execute the individual
+// KubeOne Remote commands on the remote node.
+package execute
+
+import (
+	"fmt"
+
+	"github.com/kubermatic-labs/kubeone-remote/pkg/config"
+)
+
+// Executer defines the interface the executing type for the individual
+// commands based on the addressed tool (kubeone-emote, kubeone, helm,
+// kubectl, ...).
+type Executer interface {
+	// Do executes the command.
+	Do(cfg config.Config) error
+}
+
+// Switch determines which Executer implementation later is responsible
+// for the command execution.
+func Switch(cfg config.Config) (Executer, error) {
+	return nil, fmt.Errorf("not yet implemented")
+}

--- a/pkg/remote/execute/execute.go
+++ b/pkg/remote/execute/execute.go
@@ -26,12 +26,28 @@ import (
 // commands based on the addressed tool (kubeone-emote, kubeone, helm,
 // kubectl, ...).
 type Executer interface {
+	// Init prepares the Executer for its work.
+	Init(cfg config.Config) Executer
+
+	// HandlesCommand checks if the Executer can handle the given command.
+	HandlesCommand() bool
+
 	// Do executes the command.
-	Do(cfg config.Config) error
+	Do() error
 }
 
 // Switch determines which Executer implementation later is responsible
 // for the command execution.
 func Switch(cfg config.Config) (Executer, error) {
-	return nil, fmt.Errorf("not yet implemented")
+	kubeOneRemoteExec := NewKubeOneRemoteExecuter().Init(cfg)
+	kubeOneExec := NewKubeOneExecuter().Init(cfg)
+
+	switch {
+	case kubeOneRemoteExec.HandlesCommand():
+		return kubeOneRemoteExec, nil
+	case kubeOneExec.HandlesCommand():
+		return kubeOneExec, nil
+	default:
+		return nil, fmt.Errorf("not yet implemented")
+	}
 }

--- a/pkg/remote/execute/kubeone-remote.go
+++ b/pkg/remote/execute/kubeone-remote.go
@@ -1,0 +1,49 @@
+// Copyright 2020 The KubeOne-Remote Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package execute
+
+import (
+	"fmt"
+
+	"github.com/kubermatic-labs/kubeone-remote/pkg/config"
+)
+
+// kubeoneRemoteExecuter implements the Executer for commands
+// of KubeOne Remote.
+type kubeOneRemoteExecuter struct {
+	cfg config.Config
+}
+
+// NewKubeOneRemoteExecuter returns the Executer for KubeOne Remote.
+func NewKubeOneRemoteExecuter() Executer {
+	return &kubeOneRemoteExecuter{}
+}
+
+// Init implements Executer.
+func (e *kubeOneRemoteExecuter) Init(cfg config.Config) Executer {
+	e.cfg = cfg
+
+	return e
+}
+
+// HandlesCommand implements Executer.
+func (e *kubeOneRemoteExecuter) HandlesCommand() bool {
+	return false
+}
+
+// Do implements Executer.
+func (e *kubeOneRemoteExecuter) Do() error {
+	return fmt.Errorf("done nothing")
+}

--- a/pkg/remote/execute/kubeone.go
+++ b/pkg/remote/execute/kubeone.go
@@ -1,0 +1,49 @@
+// Copyright 2020 The KubeOne-Remote Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package execute
+
+import (
+	"fmt"
+
+	"github.com/kubermatic-labs/kubeone-remote/pkg/config"
+)
+
+// kubeoneExecuter implements the Executer for commands
+// of KubeOne.
+type kubeOneExecuter struct {
+	cfg config.Config
+}
+
+// NewKubeOneExecuter returns the Executer for KubeOne.
+func NewKubeOneExecuter() Executer {
+	return &kubeOneExecuter{}
+}
+
+// Init implements Executer.
+func (e *kubeOneExecuter) Init(cfg config.Config) Executer {
+	e.cfg = cfg
+
+	return e
+}
+
+// HandlesCommand implements Executer.
+func (e *kubeOneExecuter) HandlesCommand() bool {
+	return false
+}
+
+// Do implements Executer.
+func (e *kubeOneExecuter) Do() error {
+	return fmt.Errorf("done nothing")
+}

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	"github.com/kubermatic-labs/kubeone-remote/pkg/config"
+	"github.com/kubermatic-labs/kubeone-remote/pkg/remote/execute"
 	"github.com/kubermatic-labs/kubeone-remote/pkg/remote/setup"
 )
 
@@ -38,6 +39,19 @@ func Setup(cfg config.Config) error {
 	err = setup.PreRunRemoteTasks(cfg)
 	if err != nil {
 		return fmt.Errorf("setup failed pre-running remote tasks: %v", err)
+	}
+	return nil
+}
+
+// Execute performs the command on the remote node.
+func Execute(cfg config.Config) error {
+	executer, err := execute.Switch(cfg)
+	if err != nil {
+		return fmt.Errorf("cannot determine command executer: %v", err)
+	}
+	err = executer.Do(cfg)
+	if err != nil {
+		return fmt.Errorf("executing command %q failed: $v", cfg.Command, err)
 	}
 	return nil
 }

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -1,0 +1,18 @@
+// Copyright 2020 The KubeOne-Remote Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package remote provides the functions needed on the controller
+// node to execute the different commands for KubeOne and the other
+// tools.
+package remote

--- a/pkg/remote/remote.go
+++ b/pkg/remote/remote.go
@@ -16,3 +16,28 @@
 // node to execute the different commands for KubeOne and the other
 // tools.
 package remote
+
+import (
+	"fmt"
+
+	"github.com/kubermatic-labs/kubeone-remote/pkg/config"
+	"github.com/kubermatic-labs/kubeone-remote/pkg/remote/setup"
+)
+
+// Setup performs all needed steps for installation and configuration
+// on the remote node.
+func Setup(cfg config.Config) error {
+	err := setup.InstallKubeOneRemote(cfg)
+	if err != nil {
+		return fmt.Errorf("setup failed installing KubeOne Remote: %v", err)
+	}
+	err = setup.CheckoutBranches(cfg)
+	if err != nil {
+		return fmt.Errorf("setup failed checking out needed branches: %v", err)
+	}
+	err = setup.PreRunRemoteTasks(cfg)
+	if err != nil {
+		return fmt.Errorf("setup failed pre-running remote tasks: %v", err)
+	}
+	return nil
+}

--- a/pkg/remote/setup/setup.go
+++ b/pkg/remote/setup/setup.go
@@ -12,24 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package local
+// Package setup provides the functionality to setup KubeOne Remote and
+// all needed tools on remote side.
+package setup
 
 import (
 	"github.com/kubermatic-labs/kubeone-remote/pkg/config"
 )
 
-// IsValidCommand checks if the given command is a valid one.
-func IsValidCommand(cmd string) bool {
-	return false
-}
-
-// PreRunLocalTasks performs initial configured tasks.
-func PreRunLocalTasks(cfg config.Config) error {
+// InstallKubeOneRemote sets up KubeOne Remote on the remote node.
+func InstallKubeOneRemote(cfg config.Config) error {
 	return nil
 }
 
-// InstallKubeOneRemote installs a KubeOne Remote copy on the controller
-// node for remote execution.
-func InstallKubeOneRemote(cfg config.Config) error {
+// CheckoutBranches cares for the ceckout of the possible needed branches
+// for Helm and KubeOne Remote.
+func CheckoutBranches(cfg config.Config) error {
+	return nil
+}
+
+// PreRunRemoteTasks performs initial configured tasks.
+func PreRunRemoteTasks(cfg config.Config) error {
 	return nil
 }


### PR DESCRIPTION
The code contains a package and function outline to be extended and glued for the KubeOne Remote port to Go.

- Issue https://github.com/kubermatic-labs/kubeone-remote/issues/8
- Issue https://github.com/kubermatic-labs/kubeone-remote/issues/9